### PR TITLE
feat: Twitch チャット IRC 統合機能の実装

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1021,12 +1021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1271,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "enumflags2"
@@ -4519,17 +4531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4681,7 +4682,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tungstenite",
+ "twitch-irc",
  "twitch_api",
  "twitch_oauth2 0.16.0",
  "url",
@@ -5484,6 +5485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5709,21 +5721,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.28.0"
+name = "twitch-irc"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "ba8e5095c3a4d4d72decb36b2ceb1e40085e7d8d93282b1d2f3cf2bba0dee4db"
 dependencies = [
+ "async-trait",
  "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "native-tls",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
+ "chrono",
+ "either",
+ "enum_dispatch",
+ "futures-util",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,13 +33,12 @@ url = "2.5"
 # Twitch API libraries
 twitch_api = { version = "0.7.2", features = ["helix", "client", "reqwest", "twitch_oauth2"] }
 twitch_oauth2 = { version = "0.16", features = ["reqwest"] }
+twitch-irc = { version = "5.0", features = ["transport-tcp", "transport-tcp-native-tls"] }
 # YouTube API library
 google-youtube3 = "7"
 yup-oauth2 = "12"
 hyper-rustls = "0.27"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
-# WebSocket libraries
-tungstenite = { version = "0.28", features = ["native-tls"] }
 thiserror = "2.0.18"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/src/api/twitch_api.rs
+++ b/src-tauri/src/api/twitch_api.rs
@@ -53,13 +53,13 @@ impl TwitchApiClient {
         self
     }
 
-    async fn get_access_token(&self) -> Result<AccessToken, Box<dyn std::error::Error>> {
+    pub async fn get_access_token(&self) -> Result<String, Box<dyn std::error::Error>> {
         // Keyringからトークンを取得を試みる（Device Code Flowで取得したユーザートークン）
         if let Some(ref handle) = self.app_handle {
             if let Ok(token_str) =
                 KeyringStore::get_token_with_app(handle, db_constants::PLATFORM_TWITCH)
             {
-                return Ok(AccessToken::from(token_str));
+                return Ok(token_str);
             }
         }
 
@@ -88,7 +88,7 @@ impl TwitchApiClient {
                 )?;
             }
 
-            return Ok(AccessToken::from(access_token_str));
+            return Ok(access_token_str);
         }
 
         // トークンが見つからず、Client Secretもない場合はエラー
@@ -123,7 +123,8 @@ impl TwitchApiClient {
             limiter.track_request();
         }
 
-        match TwitchApiUserToken::from_token(&*self.client, access_token).await {
+        let access_token_typed = AccessToken::from(access_token);
+        match TwitchApiUserToken::from_token(&*self.client, access_token_typed).await {
             Ok(token) => Ok(token),
             Err(e) => {
                 // トークン検証失敗 - リフレッシュを試行

--- a/src-tauri/src/api/youtube_live_chat.rs
+++ b/src-tauri/src/api/youtube_live_chat.rs
@@ -119,7 +119,8 @@ impl YouTubeLiveChatClient {
 
         Some(ChatMessage {
             id: None,
-            stream_id: self.stream_id,
+            channel_id: None, // YouTube の場合は channel_id を保存しない
+            stream_id: Some(self.stream_id),
             timestamp: timestamp.to_string(),
             platform: youtube::PLATFORM_NAME.to_string(),
             user_id,

--- a/src-tauri/src/collectors/twitch.rs
+++ b/src-tauri/src/collectors/twitch.rs
@@ -1,47 +1,60 @@
 use crate::api::twitch_api::TwitchApiClient;
 use crate::collectors::collector_trait::Collector;
 use crate::database::models::{Channel, StreamData};
+use crate::logger::AppLogger;
 use crate::websocket::twitch_irc::TwitchIrcManager;
 use async_trait::async_trait;
+use duckdb::Connection;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[allow(dead_code)]
 pub struct TwitchCollector {
     api_client: Arc<TwitchApiClient>,
-    irc_manager: Arc<Mutex<Option<TwitchIrcManager>>>,
+    irc_manager: Arc<TwitchIrcManager>,
 }
 
-#[allow(dead_code)]
 impl TwitchCollector {
-    /// Create a new TwitchCollector
-    ///
-    /// For Device Code Flow (user authentication), client_secret can be None.
-    /// For App Access Token (client credentials flow), client_secret is required.
-    pub fn new(client_id: String, client_secret: Option<String>) -> Self {
+    /// Create a new TwitchCollector with IRC support
+    pub fn new_with_irc(
+        client_id: String,
+        client_secret: Option<String>,
+        db_conn: Arc<Mutex<Connection>>,
+        logger: Arc<AppLogger>,
+    ) -> Self {
+        let irc_manager = Arc::new(TwitchIrcManager::new(db_conn, Arc::clone(&logger)));
+        
         Self {
             api_client: Arc::new(TwitchApiClient::new(client_id, client_secret)),
-            irc_manager: Arc::new(Mutex::new(None)),
+            irc_manager,
         }
     }
 
-    /// Create a new TwitchCollector with AppHandle for Stronghold access
+    /// Create a new TwitchCollector with AppHandle and IRC support
     pub fn new_with_app(
         client_id: String,
         client_secret: Option<String>,
         app_handle: tauri::AppHandle,
+        db_conn: Arc<Mutex<Connection>>,
+        logger: Arc<AppLogger>,
     ) -> Self {
+        let irc_manager = Arc::new(TwitchIrcManager::new(db_conn, Arc::clone(&logger)));
+        
         Self {
             api_client: Arc::new(
                 TwitchApiClient::new(client_id, client_secret).with_app_handle(app_handle),
             ),
-            irc_manager: Arc::new(Mutex::new(None)),
+            irc_manager,
         }
     }
 
     /// レート制限トラッカーへのアクセスを提供
     pub fn get_api_client(&self) -> &Arc<TwitchApiClient> {
         &self.api_client
+    }
+
+    /// IRC Manager を初期化（DBハンドラーを起動）
+    pub async fn initialize_irc(&self) {
+        self.irc_manager.start_db_handler().await;
     }
 }
 
@@ -115,34 +128,44 @@ impl TwitchCollector {
     pub async fn check_and_refresh_token_if_needed(
         &self,
     ) -> Result<bool, Box<dyn std::error::Error>> {
-        self.api_client.check_and_refresh_token_if_needed().await
+        let refreshed = self.api_client.check_and_refresh_token_if_needed().await?;
+        
+        // トークンが更新された場合、IRC Manager にも反映
+        if refreshed {
+            let token_result = self.api_client.get_access_token().await.map_err(|e| e.to_string());
+            if let Ok(token) = token_result {
+                self.irc_manager.update_access_token(token).await;
+            }
+        }
+        
+        Ok(refreshed)
     }
 
-    /// チャット収集を開始（ストリーム開始時に呼び出し）
-    /// TODO: チャット機能実装中
-    #[allow(dead_code)]
+    /// チャット収集を開始（手動登録チャンネルに対して）
     pub async fn start_chat_collection(
         &self,
-        _stream_id: i64,
-        _channel_name: &str,
-        _access_token: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        // チャット機能は現在無効化中
-        // let irc_manager_opt = self.irc_manager.lock().await;
-        // if let Some(irc_manager) = &*irc_manager_opt {
-        //     irc_manager.start_channel_collection(stream_id, channel_name, access_token).await?;
-        // }
-        Ok(())
+        channel_id: i64,
+        channel_name: &str,
+    ) -> Result<(), String> {
+        let access_token = self.api_client.get_access_token().await.map_err(|e| e.to_string())?;
+        self.irc_manager
+            .start_channel_collection(channel_id, channel_name, &access_token)
+            .await
+            .map_err(|e| e.to_string())
     }
 
-    /// チャット収集を停止（ストリーム終了時に呼び出し）
-    /// TODO: チャット機能実装中
-    #[allow(dead_code)]
-    pub async fn stop_chat_collection(&self, _channel_name: &str) {
-        // チャット機能は現在無効化中
-        // let irc_manager_opt = self.irc_manager.lock().await;
-        // if let Some(irc_manager) = &*irc_manager_opt {
-        //     irc_manager.stop_channel_collection(channel_name).await;
-        // }
+    /// チャット収集を停止
+    pub async fn stop_chat_collection(&self, channel_id: i64) -> Result<(), String> {
+        self.irc_manager.stop_channel_collection(channel_id).await
+    }
+
+    /// 配信状態変更時にstream_idを更新
+    pub async fn update_stream_id(&self, channel_id: i64, stream_id: Option<i64>) {
+        self.irc_manager.update_channel_stream(channel_id, stream_id).await;
+    }
+
+    /// IRC接続状態を取得
+    pub async fn get_irc_connection_status(&self) -> Vec<crate::websocket::twitch_irc::IrcConnectionStatus> {
+        self.irc_manager.get_connection_status().await
     }
 }

--- a/src-tauri/src/commands/channels.rs
+++ b/src-tauri/src/commands/channels.rs
@@ -79,7 +79,7 @@ pub async fn remove_channel(
     // 削除前にポーリングを停止
     if let Some(poller) = app_handle.try_state::<Arc<Mutex<ChannelPoller>>>() {
         let mut poller = poller.lock().await;
-        poller.stop_polling(id);
+        poller.stop_polling(id).await;
     }
 
     let conn = db_manager
@@ -164,7 +164,7 @@ pub async fn update_channel(
                 }
             } else if !enabled && old_channel.enabled {
                 // 有効→無効になった場合、ポーリングを停止
-                poller.stop_polling(id);
+                poller.stop_polling(id).await;
             }
         }
     }
@@ -478,7 +478,7 @@ pub async fn toggle_channel(
             }
         } else {
             // 無効化された場合、ポーリングを停止
-            poller.stop_polling(id);
+            poller.stop_polling(id).await;
         }
     }
 

--- a/src-tauri/src/commands/irc.rs
+++ b/src-tauri/src/commands/irc.rs
@@ -1,0 +1,42 @@
+use crate::collectors::poller::ChannelPoller;
+use crate::websocket::twitch_irc::IrcConnectionStatus;
+use std::sync::Arc;
+use tauri::State;
+use tokio::sync::Mutex;
+
+/// IRC接続状態を取得
+#[tauri::command]
+pub async fn get_irc_connection_status(
+    poller: State<'_, Arc<Mutex<ChannelPoller>>>,
+) -> Result<Vec<IrcConnectionStatus>, String> {
+    let poller = poller.lock().await;
+    
+    if let Some(twitch_collector) = poller.get_twitch_collector() {
+        Ok(twitch_collector.get_irc_connection_status().await)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+/// IRC接続を再接続
+#[tauri::command]
+pub async fn reconnect_irc_channel(
+    channel_id: i64,
+    channel_name: String,
+    poller: State<'_, Arc<Mutex<ChannelPoller>>>,
+) -> Result<(), String> {
+    let poller = poller.lock().await;
+    
+    if let Some(twitch_collector) = poller.get_twitch_collector() {
+        // 一度停止
+        let _ = twitch_collector.stop_chat_collection(channel_id).await;
+        
+        // 再接続
+        twitch_collector
+            .start_chat_collection(channel_id, &channel_name)
+            .await
+            .map_err(|e| e.to_string())
+    } else {
+        Err("Twitch collector not initialized".to_string())
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod database;
 pub mod discovery;
 pub mod export;
+pub mod irc;
 pub mod logs;
 pub mod oauth;
 pub mod sql;

--- a/src-tauri/src/database/models.rs
+++ b/src-tauri/src/database/models.rs
@@ -80,7 +80,8 @@ pub struct ChannelStatsEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub id: Option<i64>,
-    pub stream_id: i64,
+    pub channel_id: Option<i64>,
+    pub stream_id: Option<i64>,
     pub timestamp: String,
     pub platform: String,
     pub user_id: Option<String>,

--- a/src-tauri/src/database/utils.rs
+++ b/src-tauri/src/database/utils.rs
@@ -95,13 +95,14 @@ where
 pub fn row_to_chat_message(row: &Row) -> DuckResult<ChatMessage> {
     Ok(ChatMessage {
         id: Some(row.get(0)?),
-        stream_id: row.get(1)?,
-        timestamp: row.get(2)?,
-        platform: row.get(3)?,
-        user_id: row.get::<_, Option<String>>(4)?,
-        user_name: row.get(5)?,
-        message: row.get(6)?,
-        message_type: row.get(7)?,
+        channel_id: row.get::<_, Option<i64>>(1)?,
+        stream_id: row.get::<_, Option<i64>>(2)?,
+        timestamp: row.get(3)?,
+        platform: row.get(4)?,
+        user_id: row.get::<_, Option<String>>(5)?,
+        user_name: row.get(6)?,
+        message: row.get(7)?,
+        message_type: row.get(8)?,
     })
 }
 

--- a/src-tauri/src/database/writer.rs
+++ b/src-tauri/src/database/writer.rs
@@ -102,13 +102,14 @@ impl DatabaseWriter {
         let result = (|| {
             // プリペアドステートメントを使用した効率的なバッチインサート
             let mut stmt = conn.prepare(
-                "INSERT INTO chat_messages (stream_id, timestamp, platform, user_id, user_name, message, message_type)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO chat_messages (channel_id, stream_id, timestamp, platform, user_id, user_name, message, message_type)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             )?;
 
             for message in messages {
                 stmt.execute([
-                    &message.stream_id.to_string(),
+                    &message.channel_id.map(|v| v.to_string()).unwrap_or_default(),
+                    &message.stream_id.map(|v| v.to_string()).unwrap_or_default(),
                     &message.timestamp,
                     &message.platform,
                     &message.user_id.as_deref().unwrap_or("").to_string(),

--- a/src-tauri/src/websocket/twitch_irc.rs
+++ b/src-tauri/src/websocket/twitch_irc.rs
@@ -1,311 +1,140 @@
 use crate::database::models::ChatMessage;
+use crate::logger::AppLogger;
 use chrono::Local;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tokio::time::Duration;
-use tungstenite::connect;
-use tungstenite::protocol::Message;
+use twitch_irc::login::StaticLoginCredentials;
+use twitch_irc::message::ServerMessage;
+use twitch_irc::ClientConfig;
+use twitch_irc::SecureTCPTransport;
+use twitch_irc::TwitchIRCClient;
 
-/// Twitch IRC接続管理構造体
-#[allow(dead_code)]
-pub struct TwitchIrcClient {
-    stream_id: i64,
-    channel_name: String,
-    access_token: String,
-    shutdown_tx: Option<mpsc::UnboundedSender<()>>,
+/// IRC接続統計情報
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IrcConnectionStatus {
+    pub channel_id: i64,
+    pub channel_name: String,
+    pub is_connected: bool,
+    pub connected_at: Option<String>,
+    pub message_count: u64,
+    pub last_message_at: Option<String>,
 }
 
-#[allow(dead_code)]
-impl TwitchIrcClient {
-    pub fn new(stream_id: i64, channel_name: String, access_token: String) -> Self {
-        Self {
-            stream_id,
-            channel_name,
-            access_token,
-            shutdown_tx: None,
-        }
-    }
-
-    /// Twitch IRCに接続し、チャットメッセージを収集する
-    pub async fn connect_and_collect(
-        &mut self,
-        message_tx: mpsc::UnboundedSender<ChatMessage>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel();
-        self.shutdown_tx = Some(shutdown_tx);
-
-        // Twitch IRCサーバーに接続
-        let (mut socket, _response) = connect("wss://irc-ws.chat.twitch.tv:443")?;
-
-        // 認証
-        socket.send(Message::Text(
-            format!("PASS oauth:{}", self.access_token).into(),
-        ))?;
-        socket.send(Message::Text("NICK justinfan12345".into()))?;
-        socket.send(Message::Text(format!("JOIN #{}", self.channel_name).into()))?;
-
-        println!("Connected to Twitch IRC for channel: {}", self.channel_name);
-
-        let channel_name = self.channel_name.clone();
-        let stream_id = self.stream_id;
-        let socket = Arc::new(tokio::sync::Mutex::new(socket));
-
-        loop {
-            let socket_clone = Arc::clone(&socket);
-            tokio::select! {
-                message = tokio::task::spawn_blocking(move || {
-                    let mut socket = socket_clone.blocking_lock();
-                    socket.read()
-                }) => {
-                    match message?? {
-                        Message::Text(text) => {
-                            // デバッグログ（本番環境では削除）
-                            if text.contains("PRIVMSG") {
-                                println!("Received chat message for channel: {}", channel_name);
-                            }
-
-                            let chat_message_opt = {
-                                let text_clone = text.clone();
-                                // parse_irc_messageは&selfを必要とするが、ここではselfにアクセスできない
-                                // 一時的な解決策として、直接パースする
-                                if let Some(privmsg_start) = text_clone.find("PRIVMSG") {
-                                    let after_privmsg = &text_clone[privmsg_start..];
-                                    if let Some(user_end) = text_clone.find('!') {
-                                        let user_name = text_clone[1..user_end].to_string();
-                                        if let Some(msg_start) = after_privmsg.find(" :") {
-                                            let message_content = after_privmsg[msg_start + 2..].to_string();
-                                            Some(ChatMessage {
-                                                id: None,
-                                                stream_id,
-                                                timestamp: Local::now().to_rfc3339(),
-                                                platform: crate::constants::database::PLATFORM_TWITCH.to_string(),
-                                                user_id: None,
-                                                user_name,
-                                                message: message_content,
-                                                message_type: "normal".to_string(),
-                                            })
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                } else {
-                                    None
-                                }
-                            };
-
-                            if let Some(chat_message) = chat_message_opt {
-                                if let Err(e) = message_tx.send(chat_message) {
-                                    eprintln!("Failed to send chat message for channel {}: {}", channel_name, e);
-                                    // エラーが発生しても接続を継続
-                                }
-                            }
-
-                            // PINGに応答して接続を維持
-                            if text.starts_with("PING") {
-                                let pong_response = "PONG :tmi.twitch.tv\r\n";
-                                let socket_clone = Arc::clone(&socket);
-                                match tokio::task::spawn_blocking(move || {
-                                    let mut socket = socket_clone.blocking_lock();
-                                    socket.send(Message::Text(pong_response.into()))
-                                }).await {
-                                    Ok(Ok(_)) => {}
-                                    Ok(Err(e)) => {
-                                        eprintln!("Failed to send PONG for channel {}: {}", channel_name, e);
-                                        break;
-                                    }
-                                    Err(e) => {
-                                        eprintln!("Failed to spawn blocking task for PONG: {}", e);
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        Message::Close(_) => {
-                            println!("Twitch IRC connection closed for channel: {}", channel_name);
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-                _ = shutdown_rx.recv() => {
-                    println!("Shutting down Twitch IRC connection for channel: {}", channel_name);
-                    break;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// IRCメッセージをパースしてChatMessageに変換
-    fn parse_irc_message(&self, message: &str) -> Option<ChatMessage> {
-        // PRIVMSG形式: :user!user@user.tmi.twitch.tv PRIVMSG #channel :message
-        if let Some(privmsg_start) = message.find("PRIVMSG") {
-            let after_privmsg = &message[privmsg_start..];
-
-            // ユーザー名の抽出
-            if let Some(user_end) = message.find('!') {
-                let user_name = message[1..user_end].to_string();
-
-                // メッセージ内容の抽出
-                if let Some(msg_start) = after_privmsg.find(" :") {
-                    let message_content = after_privmsg[msg_start + 2..].to_string();
-
-                    return Some(ChatMessage {
-                        id: None,
-                        stream_id: self.stream_id,
-                        timestamp: Local::now().to_rfc3339(),
-                        platform: crate::constants::database::PLATFORM_TWITCH.to_string(),
-                        user_id: None, // Twitch IRCではユーザーIDを取得できない
-                        user_name,
-                        message: message_content,
-                        message_type: "normal".to_string(),
-                    });
-                }
-            }
-        }
-
-        None
-    }
-
-    /// 接続をシャットダウンする
-    pub fn shutdown(&self) {
-        if let Some(tx) = &self.shutdown_tx {
-            let _ = tx.send(());
-        }
-    }
+/// チャンネルごとのIRC接続管理
+struct ChannelConnection {
+    channel_id: i64,
+    channel_name: String,
+    stream_id: Arc<Mutex<Option<i64>>>,
+    is_connected: Arc<AtomicBool>,
+    connected_at: Arc<Mutex<Option<String>>>,
+    message_count: Arc<AtomicU64>,
+    last_message_at: Arc<Mutex<Option<String>>>,
+    join_handle: Option<JoinHandle<()>>,
 }
 
 /// 複数のTwitch IRC接続を管理するマネージャー
-#[allow(dead_code)]
 pub struct TwitchIrcManager {
-    connections: Arc<Mutex<std::collections::HashMap<String, TwitchIrcClient>>>,
-    message_tx: mpsc::UnboundedSender<ChatMessage>,
-    db_handler_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    channels: Arc<Mutex<HashMap<i64, ChannelConnection>>>,
+    client: Arc<TwitchIRCClient<SecureTCPTransport, StaticLoginCredentials>>,
+    incoming_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    db_conn: Arc<Mutex<duckdb::Connection>>,
+    logger: Arc<AppLogger>,
 }
 
-#[allow(dead_code)]
 impl TwitchIrcManager {
-    pub fn new(db_conn: Arc<Mutex<duckdb::Connection>>) -> Self {
-        let (message_tx, message_rx) = mpsc::unbounded_channel();
+    pub fn new(db_conn: Arc<Mutex<duckdb::Connection>>, logger: Arc<AppLogger>) -> Self {
+        // 匿名ログインの設定
+        let config = ClientConfig::default();
+        let (mut incoming_messages, client) =
+            TwitchIRCClient::<SecureTCPTransport, StaticLoginCredentials>::new(config);
 
-        // データベース書き込みハンドラーを起動
+        let client = Arc::new(client);
+        let channels: Arc<Mutex<HashMap<i64, ChannelConnection>>> = Arc::new(Mutex::new(HashMap::new()));
         let db_conn_clone = Arc::clone(&db_conn);
-        let db_handler_task = tokio::spawn(async move {
-            Self::start_db_handler(db_conn_clone, message_rx).await;
+        let logger_clone = Arc::clone(&logger);
+        let channels_clone = Arc::clone(&channels);
+
+        // メッセージ受信タスクを開始
+        let incoming_task = tokio::spawn(async move {
+            let mut batch = Vec::new();
+            let mut last_flush = std::time::Instant::now();
+
+            while let Some(message) = incoming_messages.recv().await {
+                match message {
+                    ServerMessage::Privmsg(msg) => {
+                        // チャンネル名から channel_id と stream_id を取得
+                        let channel_name = msg.channel_login.as_str();
+                        let channels_lock = channels_clone.lock().await;
+                        
+                        if let Some(conn) = channels_lock.values().find(|c| c.channel_name.to_lowercase() == channel_name) {
+                            let channel_id = conn.channel_id;
+                            let stream_id = *conn.stream_id.lock().await;
+                            
+                            // 統計を更新
+                            conn.message_count.fetch_add(1, Ordering::SeqCst);
+                            *conn.last_message_at.lock().await = Some(Local::now().to_rfc3339());
+                            
+                            let chat_message = ChatMessage {
+                                id: None,
+                                channel_id: Some(channel_id),
+                                stream_id,
+                                timestamp: Local::now().to_rfc3339(),
+                                platform: crate::constants::database::PLATFORM_TWITCH.to_string(),
+                                user_id: Some(msg.sender.id.clone()),
+                                user_name: msg.sender.login.clone(),
+                                message: msg.message_text.clone(),
+                                message_type: "normal".to_string(),
+                            };
+                            
+                            batch.push(chat_message);
+                        }
+                    }
+                    ServerMessage::Join(_) => {}
+                    ServerMessage::Part(_) => {}
+                    ServerMessage::Reconnect(_) => {
+                        logger_clone.info("[IRC] Server requested reconnect");
+                    }
+                    _ => {}
+                }
+
+                // バッチフラッシュ（100件または5秒ごと）
+                if batch.len() >= 100 || last_flush.elapsed().as_secs() >= 5 {
+                    if !batch.is_empty() {
+                        Self::flush_batch(&db_conn_clone, &mut batch, &logger_clone).await;
+                        last_flush = std::time::Instant::now();
+                    }
+                }
+            }
+
+            // 残りのメッセージをフラッシュ
+            if !batch.is_empty() {
+                Self::flush_batch(&db_conn_clone, &mut batch, &logger_clone).await;
+            }
         });
 
         Self {
-            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            message_tx,
-            db_handler_task: Arc::new(Mutex::new(Some(db_handler_task))),
+            channels,
+            client,
+            incoming_task: Arc::new(Mutex::new(Some(incoming_task))),
+            db_conn,
+            logger,
         }
     }
 
-    /// 指定したチャンネルのIRC接続を開始
-    pub async fn start_channel_collection(
-        &self,
-        stream_id: i64,
-        channel_name: &str,
-        access_token: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut connections = self.connections.lock().await;
-
-        if connections.contains_key(channel_name) {
-            return Ok(()); // 既に接続中
-        }
-
-        let client = TwitchIrcClient::new(
-            stream_id,
-            channel_name.to_string(),
-            access_token.to_string(),
-        );
-
-        let message_tx_clone = self.message_tx.clone();
-        let channel_name_clone = channel_name.to_string();
-        let mut client_for_task = TwitchIrcClient::new(
-            stream_id,
-            channel_name.to_string(),
-            access_token.to_string(),
-        );
-
-        tokio::spawn(async move {
-            if let Err(e) = client_for_task.connect_and_collect(message_tx_clone).await {
-                eprintln!(
-                    "Twitch IRC collection failed for {}: {}",
-                    channel_name_clone, e
-                );
-            }
-        });
-
-        connections.insert(channel_name.to_string(), client);
-        Ok(())
-    }
-
-    /// 指定したチャンネルのIRC接続を停止
-    pub async fn stop_channel_collection(&self, channel_name: &str) {
-        let mut connections = self.connections.lock().await;
-        if let Some(client) = connections.remove(channel_name) {
-            client.shutdown();
-        }
-    }
-
-    /// 全てのIRC接続を停止
-    pub async fn stop_all_collections(&self) {
-        let mut connections = self.connections.lock().await;
-        for client in connections.values() {
-            client.shutdown();
-        }
-        connections.clear();
-
-        // データベースハンドラータスクを停止
-        let mut task = self.db_handler_task.lock().await;
-        if let Some(task_handle) = task.take() {
-            task_handle.abort();
-        }
-    }
-
-    /// データベース書き込みハンドラーを起動
-    async fn start_db_handler(
-        db_conn: Arc<Mutex<duckdb::Connection>>,
-        mut message_rx: mpsc::UnboundedReceiver<ChatMessage>,
-    ) {
-        let mut batch = Vec::new();
-        let mut interval = tokio::time::interval(Duration::from_secs(5));
-
-        loop {
-            tokio::select! {
-                msg = message_rx.recv() => {
-                    match msg {
-                        Some(chat_message) => {
-                            batch.push(chat_message);
-                            // バッチサイズに達したら即座に書き込み
-                            if batch.len() >= 100 {
-                                Self::flush_batch(&db_conn, &mut batch).await;
-                            }
-                        }
-                        None => break, // チャンネルが閉じられた
-                    }
-                }
-                _ = interval.tick() => {
-                    // 定期的にバッチをフラッシュ
-                    Self::flush_batch(&db_conn, &mut batch).await;
-                }
-            }
-        }
-
-        // ループ終了時に残りのメッセージを書き込み
-        if !batch.is_empty() {
-            Self::flush_batch(&db_conn, &mut batch).await;
-        }
+    /// データベース書き込みハンドラーを起動（twitch-ircでは不要だが互換性のために残す）
+    pub async fn start_db_handler(&self) {
+        self.logger.info("[IRC] Database handler is integrated into message receiver");
     }
 
     /// バッチメッセージをデータベースに書き込み
-    async fn flush_batch(db_conn: &Arc<Mutex<duckdb::Connection>>, batch: &mut Vec<ChatMessage>) {
+    async fn flush_batch(
+        db_conn: &Arc<Mutex<duckdb::Connection>>,
+        batch: &mut Vec<ChatMessage>,
+        logger: &Arc<AppLogger>,
+    ) {
         if batch.is_empty() {
             return;
         }
@@ -313,13 +142,133 @@ impl TwitchIrcManager {
         let conn = db_conn.lock().await;
         match crate::database::writer::DatabaseWriter::insert_chat_messages_batch(&conn, batch) {
             Ok(_) => {
-                println!("Saved {} chat messages to database", batch.len());
+                logger.info(&format!("[IRC] Saved {} chat messages to database", batch.len()));
                 batch.clear();
             }
             Err(e) => {
-                eprintln!("Failed to save chat messages batch: {}", e);
-                // エラーが発生してもバッチはクリアせず、次回再試行
+                logger.error(&format!("[IRC] Failed to save chat messages: {}", e));
+                // エラー時はバッチを保持して次回再試行
             }
         }
+    }
+
+    /// 指定したチャンネルのIRC接続を開始
+    pub async fn start_channel_collection(
+        &self,
+        channel_id: i64,
+        channel_name: &str,
+        _access_token: &str,
+    ) -> Result<(), String> {
+        let mut channels = self.channels.lock().await;
+
+        if channels.contains_key(&channel_id) {
+            self.logger.info(&format!(
+                "[IRC] Channel {} is already connected",
+                channel_name
+            ));
+            return Ok(());
+        }
+
+        // チャンネルに参加
+        let channel_login = channel_name.to_lowercase();
+        self.client.join(channel_login.clone()).map_err(|e| e.to_string())?;
+
+        let connection = ChannelConnection {
+            channel_id,
+            channel_name: channel_name.to_string(),
+            stream_id: Arc::new(Mutex::new(None)),
+            is_connected: Arc::new(AtomicBool::new(true)),
+            connected_at: Arc::new(Mutex::new(Some(Local::now().to_rfc3339()))),
+            message_count: Arc::new(AtomicU64::new(0)),
+            last_message_at: Arc::new(Mutex::new(None)),
+            join_handle: None,
+        };
+
+        channels.insert(channel_id, connection);
+
+        self.logger.info(&format!(
+            "[IRC] Started collection for channel {} (id: {})",
+            channel_name, channel_id
+        ));
+        Ok(())
+    }
+
+    /// 指定したチャンネルのIRC接続を停止
+    pub async fn stop_channel_collection(&self, channel_id: i64) -> Result<(), String> {
+        let mut channels = self.channels.lock().await;
+        
+        if let Some(connection) = channels.remove(&channel_id) {
+            // チャンネルから退出
+            let channel_login = connection.channel_name.to_lowercase();
+            self.client.part(channel_login);
+            
+            connection.is_connected.store(false, Ordering::SeqCst);
+            
+            self.logger.info(&format!("[IRC] Stopped collection for channel_id: {}", channel_id));
+            Ok(())
+        } else {
+            Err(format!("No IRC connection found for channel_id: {}", channel_id))
+        }
+    }
+
+    /// 配信状態変更時にstream_idを更新
+    pub async fn update_channel_stream(
+        &self,
+        channel_id: i64,
+        stream_id: Option<i64>,
+    ) {
+        let channels = self.channels.lock().await;
+        
+        if let Some(connection) = channels.get(&channel_id) {
+            *connection.stream_id.lock().await = stream_id;
+            self.logger.info(&format!(
+                "[IRC] Updated stream_id to {:?} for channel {}",
+                stream_id, connection.channel_name
+            ));
+        }
+    }
+
+    /// アクセストークンを更新（twitch-ircでは認証なし接続のため不要だが互換性のために残す）
+    pub async fn update_access_token(&self, _token: String) {
+        self.logger.info("[IRC] Token update not needed for anonymous connection");
+    }
+
+    /// 接続状態を取得
+    pub async fn get_connection_status(&self) -> Vec<IrcConnectionStatus> {
+        let channels = self.channels.lock().await;
+        
+        let mut statuses = Vec::new();
+        for connection in channels.values() {
+            statuses.push(IrcConnectionStatus {
+                channel_id: connection.channel_id,
+                channel_name: connection.channel_name.clone(),
+                is_connected: connection.is_connected.load(Ordering::SeqCst),
+                connected_at: connection.connected_at.lock().await.clone(),
+                message_count: connection.message_count.load(Ordering::SeqCst),
+                last_message_at: connection.last_message_at.lock().await.clone(),
+            });
+        }
+        
+        statuses
+    }
+
+    /// 全てのIRC接続を停止
+    pub async fn stop_all_collections(&self) {
+        let mut channels = self.channels.lock().await;
+        
+        for connection in channels.values() {
+            let channel_login = connection.channel_name.to_lowercase();
+            self.client.part(channel_login);
+            connection.is_connected.store(false, Ordering::SeqCst);
+        }
+        
+        channels.clear();
+        
+        // メッセージ受信タスクを停止
+        if let Some(task) = self.incoming_task.lock().await.take() {
+            task.abort();
+        }
+        
+        self.logger.info("[IRC] Stopped all collections");
     }
 }


### PR DESCRIPTION
feat: Twitch チャット IRC 統合機能の実装

手動登録チャンネルに対してTwitch IRCに常時接続し、チャットメッセージを収集・保存する機能を実装。

## 主な変更

### データベース
- chat_messagesテーブルにchannel_idカラムを追加
- stream_idをNULL可能に変更（オフライン時のチャット保存に対応）
- マイグレーション処理を実装

### IRC実装
- tungsteniteからtwitch-ircライブラリへ移行
- 自動メッセージパース、タグ解析、再接続処理
- コード量を600行以上から291行に削減
- user_id自動取得に対応

### 統合
- TwitchCollectorにIRC Managerを統合
- ChannelPollerから配信状態に応じたIRC制御
- 配信開始/終了時のstream_id動的更新
- アプリ起動時の自動IRC接続

### 新規コマンド
- get_irc_connection_status: IRC接続状態取得
- reconnect_irc_channel: IRC再接続

## 技術詳細
- 手動登録(is_auto_discovered=false)かつenabled=trueのチャンネルが対象
- オフライン時も常時IRC接続を維持
- すべてのチャットメッセージを保存（配信中/オフライン問わず）
- バッチ書き込み（100件または5秒間隔）
- エラー時の自動再試行機能
