### PR TITLE
fix: エクスポート時にinvoke引数をcamelCaseに統一

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -75,13 +75,22 @@ pub async fn export_to_delimited(
 
             if let (Some(st), Some(et), Some(interval)) = (start_opt, end_opt, interval_minutes) {
                 StreamStatsRepository::get_interpolated_stream_stats_for_export(
-                    conn, None, Some(channel_id), st, et, interval,
+                    conn,
+                    None,
+                    Some(channel_id),
+                    st,
+                    et,
+                    interval,
                 )
                 .db_context("query interpolated stats for export")
                 .map_err(|e| e.to_string())
             } else {
                 StreamStatsRepository::get_stream_stats_filtered(
-                    conn, None, Some(channel_id), start_opt, end_opt,
+                    conn,
+                    None,
+                    Some(channel_id),
+                    start_opt,
+                    end_opt,
                     true, // ORDER BY collected_at ASC for export
                 )
                 .db_context("query stats")
@@ -177,13 +186,22 @@ pub async fn preview_export_data(
 
             if let (Some(st), Some(et), Some(interval)) = (start_opt, end_opt, interval_minutes) {
                 StreamStatsRepository::get_interpolated_stream_stats_for_export(
-                    conn, None, Some(channel_id), st, et, interval,
+                    conn,
+                    None,
+                    Some(channel_id),
+                    st,
+                    et,
+                    interval,
                 )
                 .db_context("query interpolated stats for preview")
                 .map_err(|e| e.to_string())
             } else {
                 StreamStatsRepository::get_stream_stats_filtered(
-                    conn, None, Some(channel_id), start_opt, end_opt,
+                    conn,
+                    None,
+                    Some(channel_id),
+                    start_opt,
+                    end_opt,
                     true, // ORDER BY collected_at ASC
                 )
                 .db_context("query stats")

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -24,7 +24,7 @@ export async function exportToDelimited(
 ): Promise<string> {
   return await invoke<string>('export_to_delimited', {
     query,
-    file_path: filePath,
-    include_bom: includeBom,
+    filePath,
+    includeBom,
   });
 }


### PR DESCRIPTION
## 概要
エクスポート時に保存ダイアログでファイル名・ディレクトリを指定しても、ファイルが保存されない問題を修正しました。

## 原因
Tauri 2 の xport_to_delimited コマンドは invoke の引数名を **camelCase** で受け取る仕様のため、ile_path / include_bom (snake_case) を送っていたことで \missing required key filePath\ エラーが発生し、バックエンドが呼ばれていませんでした。

## 修正内容
- \src/api/export.ts\: invoke の引数を \ilePath\ / \includeBom\ に変更
- \src-tauri/src/commands/export.rs\: cargo fmt によるフォーマット修正

Made with [Cursor](https://cursor.com)